### PR TITLE
Sample code for long-press to save recording

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -56,7 +56,7 @@
             "dependsOn": [
                 "checkforsettings"
             ],
-            "command": "ssh deck@${config:deckip} -p ${config:deckport} ${config:deckkey} 'mkdir -p ${config:deckdir}/homebrew/pluginloader && mkdir -p ${config:deckdir}/homebrew/plugins'",
+            "command": "ssh ${config:deckuser}@${config:deckip} -p ${config:deckport} ${config:deckkey} 'mkdir -p ${config:deckdir}/homebrew/pluginloader && mkdir -p ${config:deckdir}/homebrew/plugins'",
             "problemMatcher": []
         },
         {
@@ -68,7 +68,7 @@
                 "createfolders",
                 "chmodfolders"
             ],
-            "command": "rsync -azp --delete --chmod=D0755,F0755 --rsh='ssh -p ${config:deckport} ${config:deckkey}' --exclude='.git/' --exclude='.github/' --exclude='.vscode/' --exclude='node_modules/' --exclude='src/' --exclude='*.log' --exclude='.gitignore' . deck@${config:deckip}:${config:deckdir}/homebrew/plugins/${workspaceFolderBasename}",
+            "command": "rsync -azp --delete --chmod=D0755,F0755 --rsh='ssh -p ${config:deckport} ${config:deckkey}' --exclude='.git/' --exclude='.github/' --exclude='.vscode/' --exclude='node_modules/' --exclude='src/' --exclude='*.log' --exclude='.gitignore' . ${config:deckuser}@${config:deckip}:${config:deckdir}/homebrew/plugins/${workspaceFolderBasename}",
             "problemMatcher": []
         },
         {
@@ -76,7 +76,7 @@
             "detail": "chmods folders to prevent perms issues",
             "type": "shell",
             "group": "none",
-            "command": "ssh deck@${config:deckip} -p ${config:deckport} ${config:deckkey} 'echo '${config:deckpass}' | sudo -S chmod -R ug+rw ${config:deckdir}/homebrew/'",
+            "command": "ssh ${config:deckuser}@${config:deckip} -p ${config:deckport} ${config:deckkey} 'echo '${config:deckpass}' | sudo -S chmod -R ug+rw ${config:deckdir}/homebrew/'",
             "problemMatcher": []
         },
         {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ class DeckyRecorderLogic
 	{
 	serverAPI: ServerAPI;
 	pressedAt: number = Date.now();
+	shareDown: boolean = false;
 
 	constructor(serverAPI: ServerAPI) {
 		this.serverAPI = serverAPI;
@@ -80,23 +81,36 @@ class DeckyRecorderLogic
 		Start 14
 		QAM  ???
 		L5 15
-		R5 16*/
+		R5 16
+		Share 29 */
 		for (const inputs of val) {
-			if (Date.now() - this.pressedAt < 2000) {
-				continue;
-			}
-			if (inputs.ulButtons && inputs.ulButtons & (1 << 13) && inputs.ulButtons & (1 << 14)) {
-				this.pressedAt = Date.now();
-				(Router as any).DisableHomeAndQuickAccessButtons();
-				setTimeout(() => {
-					(Router as any).EnableHomeAndQuickAccessButtons();
-				}, 1000)
-				const isRolling = await this.serverAPI.callPluginMethod("is_rolling", {});
-				if (isRolling.result as boolean) {
+			// if (Date.now() - this.pressedAt < 2000) {
+			// 	continue;
+			// }
+			// if (inputs.ulButtons && inputs.ulButtons & (1 << 13) && inputs.ulButtons & (1 << 14)) {
+			// 	this.pressedAt = Date.now();
+			// 	(Router as any).DisableHomeAndQuickAccessButtons();
+			// 	setTimeout(() => {
+			// 		(Router as any).EnableHomeAndQuickAccessButtons();
+			// 	}, 1000)
+			// 	const isRolling = await this.serverAPI.callPluginMethod("is_rolling", {});
+			// 	if (isRolling.result as boolean) {
+			// 		await this.saveRollingRecording(30);
+			// 	} else {
+			// 		await this.notify("Enabling replay mode", 1500, "Steam + Start to save last 30 seconds");
+			// 		this.toggleRolling(false);
+			// 	}
+			// }
+  			if (inputs.ulButtons && (inputs.ulButtons & (1 << 29))) {
+				if ((this.shareDown == false)) {
+					this.shareDown = true;
+					this.pressedAt = Date.now();
+				}
+			} else if (this.shareDown == true) {
+				this.shareDown = false;
+				var now = Date.now();
+				if (now - this.pressedAt >= 500) { // hold for longer than 500 ms
 					await this.saveRollingRecording(30);
-				} else {
-					await this.notify("Enabling replay mode", 1500, "Steam + Start to save last 30 seconds");
-					this.toggleRolling(false);
 				}
 			}
 		}


### PR DESCRIPTION
This is the sample code to trigger saving a clip if `share` button is held down for longer than 500 ms. However, this would disallow users to remap this button for other purpose per game. Also, even if they don't remap, a screenshot will still be saved by Steam every time we save a clip, but I personally am fine with that.

Your codes to capture with `steam` + `start` are commented out because I don't know what the best way is to integrate my change into them 🥲

I've tested it to be working with an Xbox Series controller, suppose it will be the same for PS and NS controllers. Please let me know if you need help adding UI elements like enabling it, adjusting holding time length, etc.

~~If you prefer using this method, maybe we could get rid of the current key-combination solution and use holding either `QAM` or `Share` to be compatible with both Deck and controllers. But I don't have a Steam Deck thus there's no way I can test QAM...~~