### PR TITLE
Fix for MP4 audio stream not playing in some video players

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/steamdeckhomebrew/holo-base:latest
  
-RUN mkdir /pacman && pacman -Sydd --noconfirm --root /pacman --dbpath /var/lib/pacman gstreamer-vaapi gst-plugin-pipewire gst-plugins-bad gst-plugins-bad-libs gst-plugins-good
+RUN mkdir /pacman && pacman -Sydd --noconfirm --root /pacman --dbpath /var/lib/pacman gstreamer-vaapi gst-plugin-pipewire gst-plugins-bad gst-plugins-bad-libs gst-plugins-good faac
 
 RUN cd /pacman/usr/lib/gstreamer-1.0/ && rm libgstneonhttpsrc.so libgstfaad.so libgstcacasink.so libgstaasink.so libgstspandsp.so libgstgme.so libgstteletext.so libgstshout2.so libgstchromaprint.so libgstkate.so libgstwildmidi.so libgstmusepack.so libgstmplex.so libgsttimecode.so libgstavtp.so libgstwebrtc.so libgsttwolame.so libgstmpeg2enc.so libgstopenmpt.so libgstdtsdec.so libgstzbar.so libgstresindvd.so libgstdc1394.so libgstsoundtouch.so libgstmicrodns.so libgstmpg123.so libgstrtmp.so libgstopenexr.so libgstfluidsynthmidi.so libgstsvthevcenc.so libgstwavpack.so libgstde265.so libgstsrtp.so libgstladspa.so libgstdv.so
 

--- a/main.py
+++ b/main.py
@@ -359,7 +359,7 @@ class Plugin:
 
             dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             ffmpeg = subprocess.Popen(
-                f'ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c copy "{self._localFilePath}/{app_name}-{clip_duration}s-{dateTime}.{self._fileformat}"',
+                f'ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c:v copy -c:a aac -b:a 128k "{self._localFilePath}/{app_name}-{clip_duration}s-{dateTime}.{self._fileformat}"',
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,

--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ class Plugin:
     _recording_process = None
     _filepath: str = None
     _mode: str = "localFile"
-    _audioBitrate: int = 128
+    _audioBitrate: int = 320000
     _localFilePath: str = decky_plugin.HOME + "/Videos"
     _rollingRecordingFolder: str = "/dev/shm"
     _rollingRecordingPrefix: str = "Decky-Recorder-Rolling"
@@ -178,7 +178,7 @@ class Plugin:
                     break
             cmd = (
                 cmd
-                + f' pulsesrc device="Recording_{monitor}" ! audio/x-raw, channels=2 ! audioconvert ! lamemp3enc target=bitrate bitrate={self._audioBitrate} cbr=true ! sink.audio_0'
+                + f' pulsesrc device="Recording_{monitor}" ! audio/x-raw, channels=2 ! audioconvert ! faac bitrate={self._audioBitrate} rate-control=2 ! sink.audio_0'
             )
 
             # Starts the capture process
@@ -359,7 +359,7 @@ class Plugin:
 
             dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             ffmpeg = subprocess.Popen(
-                f'ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c:v copy -c:a aac -b:a 128k "{self._localFilePath}/{app_name}-{clip_duration}s-{dateTime}.{self._fileformat}"',
+                f'ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c:v copy -c:a aac -b:a 192k -af aresample=async=1000 "{self._localFilePath}/{app_name}-{clip_duration}s-{dateTime}.{self._fileformat}"',
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,


### PR DESCRIPTION
## Description

This PR addresses an issue with how the final MP4 container is formed with `ffmpeg` during rolling records. The GStreamer pipeline is encoding to `mp3` using the `lamemp3` codec, but a lot of native MP4 video players don't seem to like having a `mp3` audio stream and they end up not playing the audio (Video players like VLC will play with no problem). From previous commits, `aac` was initially removed to fix the audio and video streams being out of sync.

This fix does the following:

* Re-enable `faac` in the GStreamer pipeline and bump it's bitrate to `320kbps`.
* Change the `ffmpeg` process to:
    * Copy the video stream as is, so the video quality is not degraded.
    * Re-encode the audio stream from `aac` to `aac`, but at `192kbps` and perform asynchronous resampling at 1,000 samples per second.

[This is a sample recording](https://github.com/safijari/decky-recorder-fork/assets/1042907/eaaa84a5-541c-478e-9b94-0eabef54a832) using these changes.

### Related issues

* #17 
* #18 (Loosely related and, potentially, the culprit for the audio stream desync when using `aac`)

## Potential problems

1. Re-enabling `faac` in the GStreamer audio pipeline _might_ introduce audio desync in recordings that aren't from the rolling/replay feature. I'll need to test this to see if this happens. If it does, we can go back to `mp3` in the pipeline, but still do the encoding to `aac` with `ffmpeg`.
2. There might be a performance cost to me bumping the bitrate from `128kbps` to `320kpbs` in the GStreamer pipeline. I haven't noticed any major performance cost, but something to keep an eye on.
    * I chose a higher bitrate to _kinda_ help with the lossy-to-lossy encoding we do later when saving the final video with `ffmpeg`. It's not ideal doing lossy-to-lossy, since it can lead to audio quality degradation, but it's the best I can come up with at the moment.
3. The asynchronous resampling of the audio stream can kinda seem distorted in the final output, since it's essentially attempting to fill/squeeze in the audio stream with the video stream. You can sorta hear it in the sample video from above.

## Other notes

I'm still trying to figure out a better solution for this. I think if we can figure out how to get the VAAPI H264 encoder to have the proper timescale/timestamps, we won't have the audio desync issue and have to do any audio resampling with `ffmpeg` (Or re-encoding the audio stream too). 