### PR TITLE
save_rolling_recording: should handle slash in app_name

### DIFF
--- a/main.py
+++ b/main.py
@@ -489,7 +489,7 @@ class Plugin:
         return
 
     async def save_rolling_recording(self, clip_duration: float = 30.0, app_name: str = ""):
-        app_name = str(app_name).replace(":", " ")
+        app_name = str(app_name).replace(":", " ").replace("/", " ")
         if app_name == "" or app_name == "null":
             app_name = "Decky-Recorder"
         clip_duration = int(clip_duration)


### PR DESCRIPTION
Open this PR for fixing the following issue:

I found I was unable to save rolling recording (Home+Start for past 30 seconds) for the game "Mega Man Zero/ZX Legacy Collection", but manual recording works fine.

After checking the script, I noticed that app name is used as filename, and since `/` is a reserved word it should be removed from file name. This is handled in `start_capturing` but missed in `save_rolling_recording`, which explained the cause for above issue.

Sending this PR to also remove "/" in app_name when saving rolling records.

I've tested this fix on my Steam Deck.