### PR TITLE
Separate recordings based on app name

### DIFF
--- a/main.py
+++ b/main.py
@@ -555,8 +555,17 @@ class Plugin:
                     ff.write(f"file {str(f)}\n")
 
             dateTime = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            rolling_directory = pathlib.Path(f"{self._localFilePath}/{app_name}")
+            logger.debug(f"Creating directory if not exists: {rolling_directory.__fspath__()}")
+            rolling_directory.mkdir(exist_ok=True)
+
+            rolling_file_name = f"{app_name}-{clip_duration}s-{dateTime}"
+            logger.debug(f"Filename for recording: {rolling_file_name}")
+            rolling_file_path = f"{rolling_directory.joinpath(rolling_file_name)}.{self._fileformat}"
+            logger.debug(f"Filepath for recording: {rolling_file_path}")
+
             ffmpeg = subprocess.Popen(
-                f'ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c copy "{self._localFilePath}/{app_name}-{clip_duration}s-{dateTime}.{self._fileformat}"',
+                f'ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -vaapi_device /dev/dri/renderD128 -f concat -safe 0 -i {self._rollingRecordingFolder}/files -c copy "{rolling_file_path}"',
                 shell=True,
                 stdout=std_out_file,
                 stderr=std_err_file,

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import sys
 import traceback
 import subprocess
@@ -206,8 +207,16 @@ class Plugin:
                     )
                 if not self._rolling:
                     logger.info("Setting local filepath no rolling")
-                    self._filepath = f"{self._localFilePath}/{app_name}_{dateTime}.{self._fileformat}"
-                    fileSinkPipeline = f' filesink location="{self._filepath}.temp" '
+                    directory = pathlib.Path(f"{self._localFilePath}/{app_name}")
+                    logger.debug(f"Creating directory if not exists: {directory.__fspath__()}")
+                    directory.mkdir(exist_ok=True)
+
+                    file_name = f"{app_name}-{dateTime}"
+                    logger.debug(f"Filename for recording: {rolling_file_name}")
+                    self._filepath = f"{rolling_directory.joinpath(rolling_file_name)}.{self._fileformat}"
+                    logger.debug(f"Filepath for recording: {rolling_file_path}")
+
+                    fileSinkPipeline = f' filesink location="{self._filepath}" '
                 else:
                     logger.info("Setting local filepath")
                     fileSinkPipeline = f" splitmuxsink name=sink muxer={muxer} muxer-pad-map=x-pad-map,audio=vid location={self._filepath} max-size-time=1000000000 max-files=480"

--- a/main.py
+++ b/main.py
@@ -99,6 +99,7 @@ class Plugin:
     _watchdog_task = None
     _muxer_map = {"mp4": "matroskamux", "mkv": "matroskamux", "mov": "qtmux"}
     _wakeup_count = 1
+    _app_named_directories: bool = False
     _settings = None
 
     async def get_wakeup_count(self):
@@ -206,14 +207,19 @@ class Plugin:
                         f"{self._rollingRecordingFolder}/{self._rollingRecordingPrefix}_%02d.{self._fileformat}"
                     )
                 if not self._rolling:
-                    logger.info("Setting local filepath no rolling")
-                    directory = pathlib.Path(f"{self._localFilePath}/{app_name}")
-                    logger.debug(f"Creating directory if not exists: {directory.__fspath__()}")
-                    directory.mkdir(exist_ok=True)
+                    if self._app_named_directories:
+                        logger.debug("Setting local filepath no rolling (app-named directories)")
 
-                    file_name = f"{app_name}-{dateTime}"
-                    logger.debug(f"Filename for recording: {file_name}")
-                    self._filepath = f"{directory.joinpath(file_name)}.{self._fileformat}"
+                        directory = pathlib.Path(f"{self._localFilePath}/{app_name}")
+                        logger.debug(f"Creating directory if not exists: {directory.__fspath__()}")
+                        directory.mkdir(exist_ok=True)
+
+                        file_name = f"{app_name}-{dateTime}"
+                        logger.debug(f"Filename for recording: {file_name}")
+                        self._filepath = f"{directory.joinpath(file_name)}.{self._fileformat}"
+                    else:
+                        self._filepath = f"{self._localFilePath}/{app_name}_{dateTime}.{self._fileformat}"
+
                     logger.debug(f"Filepath for recording: {self._filepath}")
 
                     fileSinkPipeline = f' filesink location="{self._filepath}" '
@@ -482,6 +488,16 @@ class Plugin:
     async def get_local_fileformat(self):
         logger.info("Current local file format: " + self._fileformat)
         return self._fileformat
+    
+    async def enable_app_named_directories(self):
+        logger.info(f"App named directories: ON")
+        self._app_named_directories = True
+        await Plugin.saveConfig(self)
+
+    async def disable_app_named_directories(self):
+        logger.info(f"App named directories: OFF")
+        self._app_named_directories = False
+        await Plugin.saveConfig(self)
 
     async def loadConfig(self):
         logger.info("Loading settings from: {}".format(os.path.join(settingsDir, "decky-loader-settings.json")))
@@ -497,6 +513,7 @@ class Plugin:
         self._micEnabled = self._settings.getSetting("mic_enabled", False)
         self._micGain = self._settings.getSetting("mic_gain", 13.0)
         self._noiseReductionPercent = self._settings.getSetting("noise_reduction_percent", 50.0)
+        self._app_named_directories = self._settings.getSetting("app_named_directories", False)
 
         # Need this for initialization only honestly
         await Plugin.saveConfig(self)
@@ -510,6 +527,7 @@ class Plugin:
         self._settings.setSetting("mic_enabled", self._micEnabled)
         self._settings.setSetting("mic_gain", self._micGain)
         self._settings.setSetting("noise_reduction_percent", self._noiseReductionPercent )
+        self._settings.setSetting("app_named_directories", self._app_named_directories)
 
         return
 

--- a/main.py
+++ b/main.py
@@ -212,9 +212,9 @@ class Plugin:
                     directory.mkdir(exist_ok=True)
 
                     file_name = f"{app_name}-{dateTime}"
-                    logger.debug(f"Filename for recording: {rolling_file_name}")
-                    self._filepath = f"{rolling_directory.joinpath(rolling_file_name)}.{self._fileformat}"
-                    logger.debug(f"Filepath for recording: {rolling_file_path}")
+                    logger.debug(f"Filename for recording: {file_name}")
+                    self._filepath = f"{directory.joinpath(file_name)}.{self._fileformat}"
+                    logger.debug(f"Filepath for recording: {self._filepath}")
 
                     fileSinkPipeline = f' filesink location="{self._filepath}" '
                 else:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,6 +72,14 @@ class DeckyRecorderLogic
 		}
 	}
 
+    toggleAppNamedDirectories = async  (appNamedDirectoriesEnabled: boolean) => {
+        if (!appNamedDirectoriesEnabled) {
+            await this.serverAPI.callPluginMethod('enable_app_named_directories', {});
+        } else {
+            await this.serverAPI.callPluginMethod('disable_app_named_directories', {});
+        }
+    }
+
 	updateMicGain = async (newMicGain: number) => {
 		await this.serverAPI.callPluginMethod('update_mic_gain', {new_gain: newMicGain});
 	}
@@ -146,6 +154,8 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 
 	const [micSourcesList, setMicSourcesList] = useState<DropdownOption[]>([{data: "NA", label: "Default Mic"}]);
 
+    const [appNamedDirectoriesEnabled, setAppNamedDirectoriesEnabled] = useState<boolean>(false);
+
 	// const audioBitrateOption128 = { data: "128", label: "128 Kbps" } as SingleDropdownOption
 	// const audioBitrateOption192 = { data: "192", label: "192 Kbps" } as SingleDropdownOption
 	// const audioBitrateOption256 = { data: "256", label: "256 Kbps" } as SingleDropdownOption
@@ -190,6 +200,9 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 		} else {
 			setMicSource({data: getMicSource.result as string, label: getMicSource.result})
 		}
+
+        const getAppNamedDirectoriesEnabled = await serverAPI.callPluginMethod('get_app_named_directories', {});
+        setAppNamedDirectoriesEnabled(getAppNamedDirectoriesEnabled.result as boolean);
 
 		// const getModeResponse = await serverAPI.callPluginMethod('get_current_mode', {});
 		// setMode(getModeResponse.result as string);
@@ -286,6 +299,10 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 	const microphoneToggled = async () => {
 		logic.toggleMicrophone(microphoneEnabled);
 	}
+
+    const appNamedDirectoriesToggled = async () => {
+        logic.toggleAppNamedDirectories(appNamedDirectoriesEnabled);
+    }
 
 	const changeMicGain = async () => {
 		logic.updateMicGain(micGain)
@@ -405,6 +422,15 @@ const DeckyRecorder: VFC<{ serverAPI: ServerAPI, logic: DeckyRecorderLogic }> = 
 					</div> : null
 				}
 			</PanelSectionRow>
+            <PanelSectionRow>
+                <ToggleField
+                    label="App Named Directories"
+                    disabled={isCapturing}
+                    checked={appNamedDirectoriesEnabled}
+                    onChange={(e) => { setAppNamedDirectoriesEnabled(e); appNamedDirectoriesToggled(); }}
+                />
+                <div>Save recordings to directories based on the name of the currently running application.</div>
+            </PanelSectionRow>
 
 			<PanelSectionRow>
 				<Dropdown


### PR DESCRIPTION
Resolves #3 

Unless I am missing something, recordings were not previously separated into folders based on app name.
This is in spite of the related issue being closed.

## Notes
Just checked my deck and it looks like I've only been running with the first commit for months now.
I only really ever use rolling recordings, so I haven't tested non-rolling recordings.

There is some cleanup that can be done (IMO) if this is accepted.

Duplicate functionality can be extracted into a function if needed
Log statements can removed if unneeded

___
I mostly wanted to open this before I forget and to gather feedback, see if this is something others want.
If so, either I can clean this up or @safijari can do it in a way they prefer
